### PR TITLE
Don't expose Control.Monad.Extra because of clashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/on-error.cabal
+++ b/on-error.cabal
@@ -1,13 +1,14 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e7b8ed88bb235a90520161ef9d55c5da43071a66d40c07258dcdcdc19064ab3c
+-- hash: 23f9c60f703d733b85369cf495870626aa49950351bcff63fe52e5929e56e1af
 
 name:           on-error
 version:        0.0.0
 build-type:     Simple
-cabal-version:  >= 1.10
 
 library
   hs-source-dirs:
@@ -19,9 +20,8 @@ library
     , text
     , transformers
   exposed-modules:
-      Control.Monad.Extra
       Control.Monad.OnError
       Control.Monad.Trans.OnError
   other-modules:
-      Paths_on_error
+      Control.Monad.Extra
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -9,3 +9,8 @@ dependencies:
 
 library:
   source-dirs: "src"
+  exposed-modules:
+    - Control.Monad.OnError
+    - Control.Monad.Trans.OnError
+  other-modules:
+    - Control.Monad.Extra


### PR DESCRIPTION
Fix for inadvertent build errors when using with http://hackage.haskell.org/package/extra-1.6.14/docs/Control-Monad-Extra.html. Since both OnError and Trans.OnError both re-export it, use hpack to make it not exposed.